### PR TITLE
Update tidy commands for May 2026 spec + handoff refinements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "session-management",
       "description": "Maintain context and continuity between Claude Code sessions with tidyup/tidydown commands",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "source": "./plugins/jg-session",
       "author": {
         "name": "Jason Gillam"

--- a/plugins/jg-session/README.md
+++ b/plugins/jg-session/README.md
@@ -13,12 +13,13 @@ This eliminates the need to manually explain what you were working on when start
 
 ## Commands
 
+Both commands set `disable-model-invocation: true` — Claude won't auto-trigger them, you invoke them explicitly with `/tidyup` and `/tidydown`.
+
 ### /tidyup
 
 End-of-session cleanup that:
-- Ensures `.CLAUDE_LAST_SESSION.md` is in `.gitignore`
-- Updates project status documentation
-- Commits your code
+- Promotes any durable facts surfaced in the session (user preferences, project facts, feedback rules) to auto-memory **before** writing the handoff, so they survive future sessions instead of getting overwritten
+- Ensures `.CLAUDE_LAST_SESSION.md` is excluded via `.git/info/exclude` (not `.gitignore`, so it stays per-developer)
 - Creates a new session summary with:
   - What was accomplished (features, bugs fixed, refactoring)
   - Current state (what's working, what's incomplete)
@@ -29,7 +30,7 @@ End-of-session cleanup that:
 
 Start-of-session context loader that:
 - Reads `.CLAUDE_LAST_SESSION.md` from your project root
-- Uses it as context for the current session
+- Treats it as a **starting point, not authoritative state** — Claude is reminded to re-read referenced files and check `git log`/`git status` before acting on the handoff's claims
 - Informs you if no previous session exists (starting fresh)
 
 ## Installation
@@ -113,6 +114,11 @@ The tidyup command integrates with your git workflow:
 **Solution**: Ensure you have changes to commit and proper git configuration (user.name, user.email)
 
 ## Version History
+
+### 1.1.0
+- `/tidyup` now promotes durable user/project facts to auto-memory before writing the handoff, so they survive across sessions instead of being overwritten
+- `/tidydown` now reminds Claude that the handoff is a starting point, not authoritative state — verify against current files and `git log`/`git status` before acting
+- Both commands now ship `disable-model-invocation: true`, so Claude won't auto-trigger them
 
 ### 1.0.0
 - Initial release

--- a/plugins/jg-session/commands/tidydown.md
+++ b/plugins/jg-session/commands/tidydown.md
@@ -3,7 +3,13 @@ description: Start-of-session context loader — reads the previous session's ha
 disable-model-invocation: true
 ---
 
-Read the session summary from .CLAUDE_LAST_SESSION.md and use it as context for this session.
+Read the session summary from `.CLAUDE_LAST_SESSION.md` and use it as a **starting point — not authoritative state** — for this session.
+
+The handoff tells you what *was* in progress and where to look, but the code, branch, and project state may have moved since it was written. Treat its claims as hypotheses to verify, not facts to act on:
+
+- Re-read the specific files the handoff calls out before changing them.
+- Check `git log` and `git status` for commits or work that landed after the handoff was written.
+- If the handoff says "X is broken" or "Y is next," confirm against current state before committing to that framing.
 
 If the file doesn't exist, inform the user (they may be starting fresh) and proceed with their request.
 

--- a/plugins/jg-session/commands/tidydown.md
+++ b/plugins/jg-session/commands/tidydown.md
@@ -1,3 +1,8 @@
+---
+description: Start-of-session context loader — reads the previous session's handoff from .CLAUDE_LAST_SESSION.md.
+disable-model-invocation: true
+---
+
 Read the session summary from .CLAUDE_LAST_SESSION.md and use it as context for this session.
 
 If the file doesn't exist, inform the user (they may be starting fresh) and proceed with their request.

--- a/plugins/jg-session/commands/tidyup.md
+++ b/plugins/jg-session/commands/tidyup.md
@@ -1,3 +1,8 @@
+---
+description: End-of-session cleanup — saves a handoff summary to .CLAUDE_LAST_SESSION.md so the next session can pick up where this one left off.
+disable-model-invocation: true
+---
+
 We are at a good stopping point for this session. Perform the following tidy-up:
 
 1. Ensure .CLAUDE_LAST_SESSION.md is excluded from git by adding it to .git/info/exclude (check and add if missing — do NOT use .gitignore for this)

--- a/plugins/jg-session/commands/tidyup.md
+++ b/plugins/jg-session/commands/tidyup.md
@@ -5,14 +5,18 @@ disable-model-invocation: true
 
 We are at a good stopping point for this session. Perform the following tidy-up:
 
-1. Ensure .CLAUDE_LAST_SESSION.md is excluded from git by adding it to .git/info/exclude (check and add if missing — do NOT use .gitignore for this)
-2. If a session summary file (.CLAUDE_LAST_SESSION.md) exists already, then remove it.
-3. Create a new session summary in .CLAUDE_LAST_SESSION.md (in the project root) with the following sections:
+1. **Promote durable facts to memory first.** Before writing the handoff, scan this session for anything that's a *durable* user preference, project fact, feedback rule, or external reference — i.e., something still useful in *future* conversations, not just the next session. Save those to your auto-memory now. The handoff doc gets overwritten each session; memory persists. If nothing durable came up, skip this step.
 
-   * Session Summary header with today's date
-   * What was accomplished (features added, bugs fixed, refactoring done, files changed)
-   * Current state (what's working, what's incomplete or in-progress, known issues)
-   * Next steps (prioritized actions for the next session)
-   * Open questions/decisions (unresolved technical decisions, blockers, questions needing user input)
+2. Ensure `.CLAUDE_LAST_SESSION.md` is excluded from git by adding it to `.git/info/exclude` (check and add if missing — do NOT use `.gitignore` for this).
 
-4. Let the user know the session summary has been saved and they can use /tidydown in their next session to load this context
+3. If a session summary file (`.CLAUDE_LAST_SESSION.md`) exists already, remove it.
+
+4. Create a new session summary in `.CLAUDE_LAST_SESSION.md` (in the project root) with the following sections:
+
+   * **Session Summary** header with today's date
+   * **What was accomplished** (features added, bugs fixed, refactoring done, files changed)
+   * **Current state** (what's working, what's incomplete or in-progress, known issues)
+   * **Next steps** (prioritized actions for the next session)
+   * **Open questions/decisions** (unresolved technical decisions, blockers, questions needing user input)
+
+5. Let the user know the session summary has been saved and they can use `/tidydown` in their next session to load this context.


### PR DESCRIPTION
## Summary

- Validated `marketplace.json`, `plugin.json`, and the slash command files against the current Claude Code plugin/skills spec. Main drift: command files were missing YAML frontmatter. Both `/tidyup` and `/tidydown` now declare a `description` and `disable-model-invocation: true`, since they're manual workflows that shouldn't be auto-triggered (especially `/tidyup`, which writes a file and orchestrates a session checkpoint).
- Addresses #1 with two behavior refinements:
  - `/tidydown` now frames the handoff as a starting point, not authoritative state — Claude is told to re-read referenced files and check `git log`/`git status` before acting on the handoff's claims.
  - `/tidyup` now promotes durable user/project/feedback facts to auto-memory **before** writing the handoff, so they survive future sessions instead of being overwritten.
- Bumps `session-management` to **1.1.0** in `marketplace.json` and updates the plugin README to match.

Two commits, ordered for clean review:
1. `0c42cbc` — pure frontmatter additions
2. `586b420` — behavior changes, README, version bump

## Test plan

- [ ] Install the local marketplace in a sandbox project; confirm `/tidyup` and `/tidydown` show their new descriptions in the slash-command picker.
- [ ] Confirm Claude does not auto-invoke either command in a session where they'd plausibly fit (i.e. `disable-model-invocation: true` is honored).
- [ ] Run `/tidyup` in a session where a durable preference came up; confirm it lands in `MEMORY.md` and not in `.CLAUDE_LAST_SESSION.md`.
- [ ] Run `/tidydown` in a follow-up session against a stale handoff; confirm Claude verifies against current files before acting.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)