### PR TITLE
Add drift check to /tidydown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
     {
       "name": "session-management",
       "description": "Maintain context and continuity between Claude Code sessions with tidyup/tidydown commands",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "source": "./plugins/jg-session",
       "author": {
         "name": "Jason Gillam"

--- a/plugins/jg-session/commands/tidydown.md
+++ b/plugins/jg-session/commands/tidydown.md
@@ -8,8 +8,14 @@ Read the session summary from `.CLAUDE_LAST_SESSION.md` and use it as a **starti
 The handoff tells you what *was* in progress and where to look, but the code, branch, and project state may have moved since it was written. Treat its claims as hypotheses to verify, not facts to act on:
 
 - Re-read the specific files the handoff calls out before changing them.
-- Check `git log` and `git status` for commits or work that landed after the handoff was written.
 - If the handoff says "X is broken" or "Y is next," confirm against current state before committing to that framing.
+
+**Drift check — before treating the summary as context.** The summary file's mtime marks when the snapshot was taken. Check whether anything has changed in the working tree since then:
+
+- For git repos: `git status --short` for uncommitted state, plus any commits or tracked files newer than `.CLAUDE_LAST_SESSION.md`.
+- For non-git directories: `find . -newer .CLAUDE_LAST_SESSION.md -type f` (excluding obvious build/output dirs).
+
+If anything is newer, surface a brief drift note up front — which files or commits postdate the summary — so its claims about them are flagged as potentially stale. If nothing is newer, stay silent and proceed.
 
 If the file doesn't exist, inform the user (they may be starting fresh) and proceed with their request.
 


### PR DESCRIPTION
## Summary
- Adds a drift check to `/tidydown`: compares working-tree state against `.CLAUDE_LAST_SESSION.md`'s mtime and surfaces commits/files that postdate the summary, so stale claims in the handoff get flagged before being acted on.
- Removes the old generic "check git log/status" bullet, since the new drift check covers it more precisely.
- Bumps `session-management` to 1.1.1 in `marketplace.json`.

## Test plan
- [ ] Install the plugin and run `/tidydown` in a repo where commits have landed since the session file was written — verify the drift note appears.
- [ ] Run `/tidydown` immediately after `/tidyup` (no drift) — verify it stays silent and proceeds normally.
- [ ] Run `/tidydown` in a non-git directory — verify the `find -newer` path triggers correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)