### PR TITLE
feat(whats-next): add issue-triage plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,16 @@
         "name": "Jason Gillam"
       },
       "category": "productivity"
+    },
+    {
+      "name": "whats-next",
+      "description": "Triage which open GitHub issues are genuinely remaining on your current branch (open != unfinished) and get a ranked, evidence-backed shortlist of what to do next",
+      "version": "1.0.0",
+      "source": "./plugins/jg-whats-next",
+      "author": {
+        "name": "Jason Gillam"
+      },
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/jg-whats-next/.claude-plugin/plugin.json
+++ b/plugins/jg-whats-next/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "whats-next",
+  "description": "A /whats-next command that triages which open GitHub issues are genuinely remaining on your current branch (open != unfinished) and returns a ranked, evidence-backed shortlist of what to do next. Delegates the analysis to a read-only subagent.",
+  "author": {
+    "name": "Jason Gillam",
+    "url": "https://github.com/jasongilman/practical-cc"
+  },
+  "license": "CC-BY-4.0",
+  "homepage": "https://github.com/jasongilman/practical-cc/tree/main/plugins/jg-whats-next",
+  "repository": "https://github.com/jasongilman/practical-cc",
+  "keywords": [
+    "issues",
+    "triage",
+    "github",
+    "gh",
+    "planning",
+    "next-steps",
+    "whats-next",
+    "productivity"
+  ]
+}

--- a/plugins/jg-whats-next/README.md
+++ b/plugins/jg-whats-next/README.md
@@ -1,0 +1,49 @@
+# What's Next Plugin (jg-whats-next)
+
+A `/whats-next` slash command that tells you which open GitHub issues are *actually* still
+remaining on your current branch — and what to tackle next.
+
+## Overview
+
+In many repos, "open issue" drifts away from "unfinished work": GitHub only auto-closes an
+issue when a merged commit/PR uses a closing keyword (`Fixes #N`), and plenty of teams don't.
+So issues pile up `open` long after they shipped. A naive `gh issue list` overcounts the work
+that's left.
+
+This plugin does the careful version. `/whats-next` hands the analysis to a read-only subagent
+that cross-references **commit history against actual repo content** to classify each open
+issue as done-but-stale, partially done, or genuinely remaining — then returns a ranked, short
+list of what to do next, with file/commit evidence for anything it calls "done."
+
+It only reports. It does not edit files, commit, or push.
+
+## Command
+
+### /whats-next
+
+Triages open issues on the current branch and returns:
+
+- **Recommended next (shortlist)** — top 3–5 remaining/partial issues by value-vs-effort, with
+  rough effort sizing and any dependencies called out.
+- **All remaining / partial** — each open issue still needing work, with a one-line status.
+- **Likely done but still open** — stale-open issues that are candidates to just close, with
+  the commit or file that satisfies them.
+
+The command delegates to the bundled `remaining-issues` subagent (invoked as
+`whats-next:remaining-issues`), so the issue-by-issue investigation runs in its own context and
+only the shortlist comes back to your main session.
+
+## Requirements
+
+- **[GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated** (`gh auth status`).
+- The repo has a **GitHub remote and uses GitHub Issues.** The agent fails loudly (rather than
+  guessing) if `gh` is missing/unauthenticated or the repo isn't on GitHub. Non-GitHub issue
+  trackers (GitLab, Jira, etc.) are not supported.
+
+## Installation
+
+This plugin is installed by registering the practical-cc marketplace in Claude Code. Once
+registered, the `/whats-next` command becomes available automatically.
+
+For detailed installation instructions, see the
+[Claude Code Plugin Documentation](https://code.claude.com/docs/en/plugins).

--- a/plugins/jg-whats-next/agents/remaining-issues.md
+++ b/plugins/jg-whats-next/agents/remaining-issues.md
@@ -1,0 +1,91 @@
+---
+name: remaining-issues
+description: >
+  Investigates which GitHub issues are genuinely REMAINING — open issues whose fix is
+  NOT already present on the current local branch — and returns a ranked shortlist of
+  what to do next. Use whenever the user asks "what issues are remaining", "what's left",
+  "what do you recommend next", or similar. Runs read-only in its own context and returns
+  only the shortlist.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You are a triage analyst for a software project that tracks work as GitHub issues. Your one
+job: figure out which open issues still need work on the **current local branch**, and
+recommend what to do next. You return a concise report — you do NOT edit files, make commits,
+or push.
+
+## Prerequisites
+
+This agent relies on the GitHub CLI. Before analyzing, confirm the basics and **fail loudly
+rather than guessing** if they're missing:
+
+- `gh auth status` — `gh` must be installed and authenticated.
+- The repo must have a GitHub remote and use GitHub Issues. If `gh issue list` errors (no
+  remote, issues disabled, or a non-GitHub host), say so plainly and stop.
+
+## Why this is not a simple list diff
+
+Do not assume "open issue" == "remaining work." A GitHub issue only auto-closes when a merged
+commit or PR uses a closing keyword (`Fixes #N`, `Closes #N`, etc.). Many teams don't, so
+issues routinely stay `open` long after the work has shipped — `gh issue list --state closed`
+can be nearly empty even though several issues are done.
+
+Also, a bare `#N` in a commit subject is ambiguous: it may reference an **issue** or a **PR**,
+and subjects often cite both (e.g. `feat(x): ... (#5) (#14)`). So never conclude an issue is
+done from a `#N` match alone.
+
+The reliable signal is a combination of **commit history + actual repo content**: does the
+change the issue asks for actually exist on this branch?
+
+## Procedure
+
+1. **Establish the branch state.**
+   - `git branch --show-current`
+   - `git log --oneline -40` (full history reachable from HEAD — this is what "already
+     present on the current branch" means; includes work merged from other branches)
+   - `git log <default-branch>..HEAD --oneline` (what's unique to this branch). Detect the
+     default branch rather than assuming `main` — e.g.
+     `git symbolic-ref --short refs/remotes/origin/HEAD` (often `origin/main` or
+     `origin/master`), falling back to whichever of `main`/`master` exists.
+
+2. **Pull open issues with bodies:**
+   `gh issue list --state open --limit 100 --json number,title,labels,body`
+   Read each body enough to know its acceptance criteria / definition of done.
+
+3. **For each open issue, classify it** as one of:
+   - **DONE (stale-open)** — the work is clearly present on this branch (verified by
+     inspecting content, not just a commit `#N` match). These are candidates to simply
+     close, not to work on.
+   - **PARTIAL** — some of it landed, but the issue's stated scope isn't fully met.
+   - **REMAINING** — no fix on this branch yet.
+
+   To verify, actually look at the code/content the issue concerns — don't infer from titles.
+   General techniques:
+   - Read the file(s) the issue targets and check whether the asked-for change is present
+     (e.g. a "build out the X page" issue → open that page; is it still a stub or real?).
+   - `grep`/search for the placeholder, string, or symbol the issue says to add or replace.
+   - `git log --oneline -- <path>` to tie commits to a file, and `git log -S<string>` to
+     find when a specific string entered or left the codebase.
+
+4. **Rank the REMAINING + PARTIAL issues** into a shortlist (top 3–5) by a rough
+   value-vs-effort read: user-facing or release-blocking items and quick wins rank above
+   nice-to-haves. Note dependencies between issues (e.g. a consent banner before analytics).
+
+## Output format
+
+Return ONLY this (no preamble), Markdown:
+
+### Recommended next (shortlist)
+1. **#N — title** — one line on why it's next + rough effort (S/M/L). Note dependencies.
+2. ...
+
+### All remaining / partial
+- **#N — title** — REMAINING | PARTIAL — one-line status (what's missing).
+
+### Likely done but still open (consider closing)
+- **#N — title** — what on the branch satisfies it (commit/file evidence). If empty, say "none".
+
+Keep it tight. Cite issue numbers and, where you claim something is done, the file or commit
+that proves it. If `gh` isn't authenticated or a command fails, say so plainly rather than
+guessing.

--- a/plugins/jg-whats-next/commands/whats-next.md
+++ b/plugins/jg-whats-next/commands/whats-next.md
@@ -1,0 +1,16 @@
+---
+description: Triage which open GitHub issues are still remaining on the current branch and recommend what to do next.
+---
+
+Launch the `remaining-issues` subagent (via the Agent tool, with
+`subagent_type: "whats-next:remaining-issues"`) to investigate which open GitHub issues are
+genuinely remaining — i.e. open issues whose fix is NOT already present on the current local
+branch — and to return a ranked shortlist of what to do next.
+
+Do the analysis in the subagent's own context. When it returns, relay its shortlist to me
+verbatim (you may add a one-line note if something looks off, e.g. `gh` wasn't authenticated
+or the repo has no GitHub remote).
+
+Do not start implementing any issue unless I ask.
+
+$ARGUMENTS


### PR DESCRIPTION
## What

Adds the **`jg-whats-next`** plugin: a `/whats-next` command that triages which open GitHub issues are *genuinely* remaining on the current branch (open != unfinished) and returns a ranked, evidence-backed shortlist of what to do next.

Promoted from a project-local command + agent so it's reusable across any GitHub repo.

## How it works

- `commands/whats-next.md` — the `/whats-next` command. Delegates to the bundled subagent via the **scoped** name `subagent_type: "whats-next:remaining-issues"` (plugin agents are namespaced by plugin name; the bare name only resolves for project/user agents).
- `agents/remaining-issues.md` — read-only triage agent. Cross-references **commit history against actual repo content** rather than trusting a bare `#N` commit match, classifies each open issue as done-but-stale / partial / remaining, and returns a shortlist with file/commit evidence.
- Registered in `.claude-plugin/marketplace.json` (v1.0.0, `productivity`).

## Generalization notes (vs. the original project-local version)

- Stripped all project-specific framing and file paths → repo-agnostic verification techniques.
- Reframed "merged PRs don't auto-close issues" from a stated fact into the portable, true-everywhere caution (issues only auto-close on a `Fixes #N` keyword).
- Default-branch detection instead of a hardcoded `main`.
- Neutral value-vs-effort ranking instead of a marketing-site lens.
- Added a **Prerequisites** section so the agent fails loudly (not silently guesses) when `gh` is unauthenticated or the repo isn't on GitHub.

## Requirements

`gh` installed + authenticated; repo on GitHub using GitHub Issues. Non-GitHub trackers are out of scope.

## Conventions followed

Version lives only in `marketplace.json`; `jg-` dir prefix; command frontmatter has `description`. Command left model-invocable (read-only, no side effects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)